### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/iJoshuaHD/tlcmd/Main.php
+++ b/src/iJoshuaHD/tlcmd/Main.php
@@ -25,7 +25,6 @@ class Main extends PluginBase implements Listener{
 		$this->getServer()->getPluginManager()->registerEvents($this, $this);
 		$this->getLogger()->info(TextFormat::YELLOW . "TimeLimitCMD Initializing [...]");
 		$this->saveDefaultConfig();
-		$this->reloadConfig();
 		$this->createCMD();
 		
 		$this->cfg = new Config($this->getDataFolder(). "config.yml", Config::YAML);
@@ -39,7 +38,7 @@ class Main extends PluginBase implements Listener{
 		
 		$fileLocation = $this->getDataFolder() . "cmd.txt";
 		if(!file_exists($fileLocation)){
-			fopen($fileLocation,"w");
+			touch($fileLocation);
 		}
 
 	}


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:
- `Plugin->getResource()` without `fclose()` calls later
- Not needed `Plugin->getResource()` calls
- `fopen()` calls without `fclose()`
- `popen()` calls without `pclose()`
